### PR TITLE
Updates version and adds -V to show the version

### DIFF
--- a/lib/Psh.pm
+++ b/lib/Psh.pm
@@ -2,7 +2,7 @@ package Psh;
 
 use vars qw($VERSION);
 
-$VERSION='1.8.1';
+$VERSION='1.8.2.dev';
 
 BEGIN {
 	require Psh::OS;

--- a/lib/Psh/Locale/Default.pm
+++ b/lib/Psh/Locale/Default.pm
@@ -70,6 +70,7 @@ usage_setenv=Usage: setenv <variable> <value>
 usage_export=Usage: export <variable> [=] <value>\n       export <variable
 usage_kill=Usage: kill <sig> <pid>| -l 
 usage_delenv=Usage: delenv <var> [<var2> <var3> ...]
+version=%1 Version %2
 bi_export_tied=Variable \$%1 is already tied via %2, cannot export.
 bi_kill_no_such_job=kill: No such job %1
 bi_kill_no_such_jobspec=kill: Unknown job specification %1

--- a/psh
+++ b/psh
@@ -14,6 +14,9 @@ use Psh;
 require Psh::Locale;
 require Psh::Util;
 
+use File::Basename;
+my $program=basename(__FILE__);  # Or use $0
+
 #
 # Parse the command line and deal with the options except -r, which is
 # handled in the MAIN program below. We do this part very early in this
@@ -28,11 +31,19 @@ my %opt=();
 
 if (@ARGV) {
 	require Getopt::Std;
-	Getopt::Std::getopts('Fiwrd:f:c:', \%opt);
+	Getopt::Std::getopts('FiwrVd:f:c:', \%opt);
 
 	if ($opt{'r'}) {
 		Psh::Util::print_error_i18n('no_r_flag');
 		exit 1;
+	}
+
+	#
+	# -V is "vresion flag":
+	#
+	if ($opt{'V'}) {
+		Psh::Util::print_warning("$program, version $Psh::VERSION\n");
+		exit 0;
 	}
 
 	#


### PR DESCRIPTION
Some other small changes. Since version1.8.1 was released in 2007, calling the current sources in git version 1.8.1 is misleading. Feel free to adjust the value. I can't remember the details but if instead you use a name like 1.8.2.beta (I used 1.8.2.dev), you can upload to CPAN and it won't be indexed as a full-fledged release. 
