### PR TITLE
Possible fix for help not printing after the first time called. 

### DIFF
--- a/lib/Psh/OS/Unix.pm
+++ b/lib/Psh/OS/Unix.pm
@@ -96,7 +96,8 @@ sub display_pod {
 
 	eval {
 		require Pod::Text;
-		Pod::Text::pod2text($tmp,*STDOUT);
+		open STDOUT_SAVE, ">&", STDOUT;
+		Pod::Text::pod2text($tmp,*STDOUT_SAVE);
 	};
 	Psh::Util::print_debug_class('e',"Error: $@") if $@;
 	print $text if $@;

--- a/lib/Psh/OS/Win.pm
+++ b/lib/Psh/OS/Win.pm
@@ -72,7 +72,8 @@ sub display_pod {
 
 	eval {
 		require Pod::Text;
-		Pod::Text::pod2text($tmp,*STDOUT);
+		open STDOUT_SAVE, ">&", STDOUT;
+		Pod::Text::pod2text($tmp,*STDOUT_SAVE);
 	};
 	print $text if $@;
 


### PR DESCRIPTION
Issue #6 - help was not showing anything after first time, because STDOUT was closed. 

Fix: dup'd STDOUT in the implementation of Psh::OS::display_pod()

Really should write a little unit test for Psh::OS::display_pod() though. 
