### PR TITLE
Fixed two issues with Win.pm

### DIFF
--- a/lib/Psh/OS/Win.pm
+++ b/lib/Psh/OS/Win.pm
@@ -134,7 +134,7 @@ sub execute_complex_command {
 			Psh::Util::print_out("[$visindex] Background $pid $string\n");
 		}
 	}
-	return ($success,@return_val);
+	return ($success,\@return_val);
 }
 
 sub _fork_process {
@@ -152,7 +152,7 @@ sub _fork_process {
 		if ($Psh::words) {
 			my $obj;
 			Win32::Process::Create($obj,
-								   @$Psh::words->[0],
+								   $Psh::words->[0],
 								   $Psh::string,
 								   0,
 								   NORMAL_PRIORITY_CLASS,


### PR DESCRIPTION
- The arrow operator expects a reference to an array on the left side
  when the right side contains [...].  Changing the @$ to just a plain
  $ removes this error and returns the same value.  This just causes
  "using an array as a reference is deprecated..." message.
- The subroutine execute_complex_command in Unix.pm returns a refernce
  to an array.  It seems like execute_complex_command in Win.pm should
  do the same. (This caused fatal errors during command execution in 
  Windows OS).
