### PR TITLE
Change deprecated *glob{FILEHANDLE} to *glob{IO}   

### DIFF
--- a/lib/Psh/Builtins/Symbols.pm
+++ b/lib/Psh/Builtins/Symbols.pm
@@ -37,7 +37,7 @@ sub bi_symbols
 			push @array,  "\@$sym" if ref *{"${pack}::$sym"}{ARRAY}  eq 'ARRAY';
 			push @hash,   "\%$sym" if ref *{"${pack}::$sym"}{HASH}   eq 'HASH';
 			push @code,   "\&$sym" if ref *{"${pack}::$sym"}{CODE}   eq 'CODE';
-			push @handle, "$sym"   if ref *{"${pack}::$sym"}{FILEHANDLE};
+			push @handle, "$sym"   if ref *{"${pack}::$sym"}{IO};
 		}
 	}
 

--- a/lib/Psh/Completion.pm
+++ b/lib/Psh/Completion.pm
@@ -309,7 +309,7 @@ sub cmpl_method {
 		my @subs = grep (/^\w+$/
 				 && ($sym = $pkg . $_,
 				     defined *$sym{CODE}
-				     || defined *$sym{FILEHANDLE}),
+				     || defined *$sym{IO}),
 				 keys %$pkg);
 		# Do we need a user customizable variable to ignore @packages?
 		my @result= grep(/^\Q$text/,

--- a/lib/Psh/Parser.pm
+++ b/lib/Psh/Parser.pm
@@ -304,7 +304,7 @@ sub parse_fileno {
 		if (/^\d+$/) {
 			push @result, $_+0;
 		} else {
-			if (ref *{"$Psh::PerlEval::current_package\:\:$_"}{FILEHANDLE}) {
+			if (ref *{"$Psh::PerlEval::current_package\:\:$_"}{IO}) {
 				push @result, fileno(*{"$Psh::PerlEval::current_package\:\:$_"});
 			}
 		}


### PR DESCRIPTION
*$sym{FILEHANDLE}) in lib/Psh/Completion.pm raised an annoying warning while trying to autocomplete using tab, so I decided to change all deprecated *glob{FILEHANDLE} to *glob{IO}.
